### PR TITLE
deleted panic log function in API Clients since not output logs.

### DIFF
--- a/pkg/jwks/jwks.go
+++ b/pkg/jwks/jwks.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 
 	"github.com/kura-lab/go-openid-connect-client/pkg/oidcconfig"
@@ -45,14 +44,8 @@ func (jWKs *JWKs) Request() (Response, error) {
 		return Response{}, err
 	}
 	defer func() {
-		_, err = io.Copy(ioutil.Discard, response.Body)
-		if err != nil {
-			log.Panic(err)
-		}
-		err = response.Body.Close()
-		if err != nil {
-			log.Panic(err)
-		}
+		io.Copy(ioutil.Discard, response.Body)
+		response.Body.Close()
 	}()
 
 	var jWKsResponse Response

--- a/pkg/oidcconfig/oidcconfig.go
+++ b/pkg/oidcconfig/oidcconfig.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 )
 
@@ -159,14 +158,8 @@ func (config *OIDCConfig) Request() error {
 	}
 	response, err := http.DefaultClient.Do(configRequest)
 	defer func() {
-		_, err = io.Copy(ioutil.Discard, response.Body)
-		if err != nil {
-			log.Panic(err)
-		}
-		err = response.Body.Close()
-		if err != nil {
-			log.Panic(err)
-		}
+		io.Copy(ioutil.Discard, response.Body)
+		response.Body.Close()
 	}()
 
 	if err != nil {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -140,14 +139,8 @@ func (token *Token) Request() (Response, error) {
 
 	response, err := http.DefaultClient.Do(tokenRequest)
 	defer func() {
-		_, err = io.Copy(ioutil.Discard, response.Body)
-		if err != nil {
-			log.Panic(err)
-		}
-		err = response.Body.Close()
-		if err != nil {
-			log.Panic(err)
-		}
+		io.Copy(ioutil.Discard, response.Body)
+		response.Body.Close()
 	}()
 
 	if err != nil {

--- a/pkg/userinfo/userinfo.go
+++ b/pkg/userinfo/userinfo.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 
 	"github.com/kura-lab/go-openid-connect-client/pkg/oidcconfig"
@@ -79,14 +78,8 @@ func (userInfo *UserInfo) Request() (Response, error) {
 	userInfoRequest.Header.Set("Authorization", "Bearer "+userInfo.accessToken)
 	response, err := http.DefaultClient.Do(userInfoRequest)
 	defer func() {
-		_, err = io.Copy(ioutil.Discard, response.Body)
-		if err != nil {
-			log.Panic(err)
-		}
-		err = response.Body.Close()
-		if err != nil {
-			log.Panic(err)
-		}
+		io.Copy(ioutil.Discard, response.Body)
+		response.Body.Close()
 	}()
 
 	if err != nil {


### PR DESCRIPTION
Closed https://github.com/kura-lab/go-openid-connect-client/issues/18

Actually, I wanna return errors in deffer function. so you need to implement named return in functions which has deffer function. But I'll have to pass on that this time.